### PR TITLE
Use hex encoded txs map

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/ShinyTrinkets/overseer v0.3.0
 	github.com/gogo/protobuf v1.3.2
-	github.com/multiversx/firehose-multiversx/types v0.0.0-20230130120255-de51c980d5d5
+	github.com/multiversx/firehose-multiversx/types v0.0.0-20230130123310-7523df5e6efd
 	github.com/multiversx/mx-chain-core-go v1.1.31-0.20230130111231-561736993b1c
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.17
 require (
 	github.com/ShinyTrinkets/overseer v0.3.0
 	github.com/gogo/protobuf v1.3.2
-	github.com/multiversx/firehose-multiversx/types v0.0.0-20230126133943-2919f97bf390
-	github.com/multiversx/mx-chain-core-go v1.1.31-0.20230126130945-26d928574f15
+	github.com/multiversx/firehose-multiversx/types v0.0.0-20230130120255-de51c980d5d5
+	github.com/multiversx/mx-chain-core-go v1.1.31-0.20230130111231-561736993b1c
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.8.1
 	github.com/streamingfast/bstream v0.0.2-0.20220909121429-4647fd1522c9

--- a/go.sum
+++ b/go.sum
@@ -532,10 +532,10 @@ github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b/go.mod h1:fQuZ0gauxyBc
 github.com/muesli/cancelreader v0.2.0/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
 github.com/muesli/termenv v0.11.1-0.20220212125758-44cd13922739/go.mod h1:Bd5NYQ7pd+SrtBSrSNoBBmXlcY8+Xj4BMJgh8qcZrvs=
-github.com/multiversx/firehose-multiversx/types v0.0.0-20230126133943-2919f97bf390 h1:QBYtXUDPPJvhAYNJuwKFT+HlpeaWKxknuyhr74G7uqw=
-github.com/multiversx/firehose-multiversx/types v0.0.0-20230126133943-2919f97bf390/go.mod h1:xXgnrlYb4j4J2B8bU8pnwjerL4gxQJm2eOSEIX2W3SU=
-github.com/multiversx/mx-chain-core-go v1.1.31-0.20230126130945-26d928574f15 h1:kdgVdMzFbhTqCrHfsYLautxfcSExiV0Cy6rFOAXuWM8=
-github.com/multiversx/mx-chain-core-go v1.1.31-0.20230126130945-26d928574f15/go.mod h1:8gGEQv6BWuuJwhd25qqhCOZbBSv9mk+hLeKvinSaSMk=
+github.com/multiversx/firehose-multiversx/types v0.0.0-20230130120255-de51c980d5d5 h1:0ol1Aq47eS+71+ahjGrimmdTKSNKK8UU492IjL0CIRg=
+github.com/multiversx/firehose-multiversx/types v0.0.0-20230130120255-de51c980d5d5/go.mod h1:aIiLJpnjj15z+LybfrPEmpJsQebM7w0Wmtc9PcHdf0A=
+github.com/multiversx/mx-chain-core-go v1.1.31-0.20230130111231-561736993b1c h1:nv1yWgwIINcGCxmZSgeAde/m7Y3ufsNjjoAX/nu24xk=
+github.com/multiversx/mx-chain-core-go v1.1.31-0.20230130111231-561736993b1c/go.mod h1:8gGEQv6BWuuJwhd25qqhCOZbBSv9mk+hLeKvinSaSMk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nicksnyder/go-i18n v1.10.1/go.mod h1:e4Di5xjP9oTVrC6y3C7C0HoSYXjSbhh/dU0eUV32nB4=

--- a/go.sum
+++ b/go.sum
@@ -532,8 +532,8 @@ github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b/go.mod h1:fQuZ0gauxyBc
 github.com/muesli/cancelreader v0.2.0/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
 github.com/muesli/termenv v0.11.1-0.20220212125758-44cd13922739/go.mod h1:Bd5NYQ7pd+SrtBSrSNoBBmXlcY8+Xj4BMJgh8qcZrvs=
-github.com/multiversx/firehose-multiversx/types v0.0.0-20230130120255-de51c980d5d5 h1:0ol1Aq47eS+71+ahjGrimmdTKSNKK8UU492IjL0CIRg=
-github.com/multiversx/firehose-multiversx/types v0.0.0-20230130120255-de51c980d5d5/go.mod h1:aIiLJpnjj15z+LybfrPEmpJsQebM7w0Wmtc9PcHdf0A=
+github.com/multiversx/firehose-multiversx/types v0.0.0-20230130123310-7523df5e6efd h1:vMeTXZzsa/JGqIUA8DXqydgRLXJsRJ6JIQq9nn52d6E=
+github.com/multiversx/firehose-multiversx/types v0.0.0-20230130123310-7523df5e6efd/go.mod h1:aIiLJpnjj15z+LybfrPEmpJsQebM7w0Wmtc9PcHdf0A=
 github.com/multiversx/mx-chain-core-go v1.1.31-0.20230130111231-561736993b1c h1:nv1yWgwIINcGCxmZSgeAde/m7Y3ufsNjjoAX/nu24xk=
 github.com/multiversx/mx-chain-core-go v1.1.31-0.20230130111231-561736993b1c/go.mod h1:8gGEQv6BWuuJwhd25qqhCOZbBSv9mk+hLeKvinSaSMk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -3,8 +3,8 @@ module github.com/multiversx/firehose-multiversx/checker
 go 1.17
 
 require (
-	github.com/multiversx/firehose-multiversx/types v0.0.0-20230126133943-2919f97bf390
-	github.com/multiversx/mx-chain-core-go v1.1.31-0.20230126130945-26d928574f15
+	github.com/multiversx/firehose-multiversx/types v0.0.0-20230130120255-de51c980d5d5
+	github.com/multiversx/mx-chain-core-go v1.1.31-0.20230130111231-561736993b1c
 	github.com/multiversx/mx-chain-crypto-go v1.2.5
 	github.com/multiversx/mx-chain-logger-go v1.0.11
 	github.com/multiversx/mx-sdk-go v1.2.3

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -3,7 +3,7 @@ module github.com/multiversx/firehose-multiversx/checker
 go 1.17
 
 require (
-	github.com/multiversx/firehose-multiversx/types v0.0.0-20230130120255-de51c980d5d5
+	github.com/multiversx/firehose-multiversx/types v0.0.0-20230130123310-7523df5e6efd
 	github.com/multiversx/mx-chain-core-go v1.1.31-0.20230130111231-561736993b1c
 	github.com/multiversx/mx-chain-crypto-go v1.2.5
 	github.com/multiversx/mx-chain-logger-go v1.0.11

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -380,8 +380,8 @@ github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjW
 github.com/mschoch/smat v0.2.0/go.mod h1:kc9mz7DoBKqDyiRL7VZN8KvXQMWeTaVnttLRXOlotKw=
 github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUYwbO0993uPI=
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
-github.com/multiversx/firehose-multiversx/types v0.0.0-20230130120255-de51c980d5d5 h1:0ol1Aq47eS+71+ahjGrimmdTKSNKK8UU492IjL0CIRg=
-github.com/multiversx/firehose-multiversx/types v0.0.0-20230130120255-de51c980d5d5/go.mod h1:aIiLJpnjj15z+LybfrPEmpJsQebM7w0Wmtc9PcHdf0A=
+github.com/multiversx/firehose-multiversx/types v0.0.0-20230130123310-7523df5e6efd h1:vMeTXZzsa/JGqIUA8DXqydgRLXJsRJ6JIQq9nn52d6E=
+github.com/multiversx/firehose-multiversx/types v0.0.0-20230130123310-7523df5e6efd/go.mod h1:aIiLJpnjj15z+LybfrPEmpJsQebM7w0Wmtc9PcHdf0A=
 github.com/multiversx/mx-chain-core-go v1.1.31-0.20230130111231-561736993b1c h1:nv1yWgwIINcGCxmZSgeAde/m7Y3ufsNjjoAX/nu24xk=
 github.com/multiversx/mx-chain-core-go v1.1.31-0.20230130111231-561736993b1c/go.mod h1:8gGEQv6BWuuJwhd25qqhCOZbBSv9mk+hLeKvinSaSMk=
 github.com/multiversx/mx-chain-crypto-go v1.2.5 h1:tuq3BUNMhKud5DQbZi9DiVAAHUXypizy8zPH0NpTGZk=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -380,10 +380,10 @@ github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjW
 github.com/mschoch/smat v0.2.0/go.mod h1:kc9mz7DoBKqDyiRL7VZN8KvXQMWeTaVnttLRXOlotKw=
 github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUYwbO0993uPI=
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
-github.com/multiversx/firehose-multiversx/types v0.0.0-20230126133943-2919f97bf390 h1:QBYtXUDPPJvhAYNJuwKFT+HlpeaWKxknuyhr74G7uqw=
-github.com/multiversx/firehose-multiversx/types v0.0.0-20230126133943-2919f97bf390/go.mod h1:xXgnrlYb4j4J2B8bU8pnwjerL4gxQJm2eOSEIX2W3SU=
-github.com/multiversx/mx-chain-core-go v1.1.31-0.20230126130945-26d928574f15 h1:kdgVdMzFbhTqCrHfsYLautxfcSExiV0Cy6rFOAXuWM8=
-github.com/multiversx/mx-chain-core-go v1.1.31-0.20230126130945-26d928574f15/go.mod h1:8gGEQv6BWuuJwhd25qqhCOZbBSv9mk+hLeKvinSaSMk=
+github.com/multiversx/firehose-multiversx/types v0.0.0-20230130120255-de51c980d5d5 h1:0ol1Aq47eS+71+ahjGrimmdTKSNKK8UU492IjL0CIRg=
+github.com/multiversx/firehose-multiversx/types v0.0.0-20230130120255-de51c980d5d5/go.mod h1:aIiLJpnjj15z+LybfrPEmpJsQebM7w0Wmtc9PcHdf0A=
+github.com/multiversx/mx-chain-core-go v1.1.31-0.20230130111231-561736993b1c h1:nv1yWgwIINcGCxmZSgeAde/m7Y3ufsNjjoAX/nu24xk=
+github.com/multiversx/mx-chain-core-go v1.1.31-0.20230130111231-561736993b1c/go.mod h1:8gGEQv6BWuuJwhd25qqhCOZbBSv9mk+hLeKvinSaSMk=
 github.com/multiversx/mx-chain-crypto-go v1.2.5 h1:tuq3BUNMhKud5DQbZi9DiVAAHUXypizy8zPH0NpTGZk=
 github.com/multiversx/mx-chain-crypto-go v1.2.5/go.mod h1:teqhNyWEqfMPgNn8sgWXlgtJ1a36jGCnhs/tRpXW6r4=
 github.com/multiversx/mx-chain-go v1.4.4 h1:sM0UlXj+JWpr9l9BMsFpwck+nSAF/8BThpR0mhiWeOw=

--- a/integration-tests/metaChecker.go
+++ b/integration-tests/metaChecker.go
@@ -67,7 +67,7 @@ func checkMetaSCRs(apiSCRs []gjson.Result, scrs map[string]*firehose.SCRInfo) er
 			return err
 		}
 
-		scrFromProtocol, found := scrs[string(hashBytes)]
+		scrFromProtocol, found := scrs[hash]
 		if !found {
 			return fmt.Errorf("checkMetaSCRs: api hash %s not found in indexed block", hash)
 		}
@@ -93,12 +93,8 @@ func checkMetaLogs(apiLog gjson.Result, logs map[string]*transaction.Log, txHash
 	if numIndexedLogs != 1 {
 		return fmt.Errorf("checkMetaLogs: expected only one generated and indexed log, received %d", numIndexedLogs)
 	}
-	txHashBytes, err := hex.DecodeString(txHash)
-	if err != nil {
-		return err
-	}
 
-	indexedLog, found := logs[string(txHashBytes)]
+	indexedLog, found := logs[txHash]
 	if !found {
 		return fmt.Errorf("checkMetaLogs: api tx hash %s not found in indexed logs", txHash)
 	}

--- a/integration-tests/metaChecker.go
+++ b/integration-tests/metaChecker.go
@@ -68,17 +68,17 @@ func checkMetaSCRs(apiSCRs []gjson.Result, scrs map[string]*firehose.SCRInfo) er
 
 	for _, apiSCR := range apiSCRs {
 		hash := apiSCR.Get("hash").String()
-		hashBytes, err := hex.DecodeString(hash)
-		if err != nil {
-			return err
-		}
-
 		scrFromProtocol, found := scrs[hash]
 		if !found {
 			return fmt.Errorf("checkMetaSCRs: api hash %s not found in indexed block", hash)
 		}
 
 		computedHash, err := mvxcore.CalculateHash(marshaller, hasher, scrFromProtocol.SmartContractResult)
+		if err != nil {
+			return err
+		}
+
+		hashBytes, err := hex.DecodeString(hash)
 		if err != nil {
 			return err
 		}

--- a/integration-tests/metaChecker.go
+++ b/integration-tests/metaChecker.go
@@ -45,7 +45,13 @@ func checkMetaBlock(apiTxResultBody string, txHash string) error {
 		return err
 	}
 
-	return checkMetaAlteredAccounts(multiversxBlock.MultiversxBlock.AlteredAccounts)
+	err = checkMetaAlteredAccounts(multiversxBlock.MultiversxBlock.AlteredAccounts)
+	if err != nil {
+		return err
+	}
+
+	log.Info("finished all metachain checks successfully")
+	return nil
 }
 
 func checkMetaSCRs(apiSCRs []gjson.Result, scrs map[string]*firehose.SCRInfo) error {

--- a/integration-tests/scripts/local-testnet.sh
+++ b/integration-tests/scripts/local-testnet.sh
@@ -19,7 +19,7 @@ cloneDependencies(){
 
   git clone https://github.com/multiversx/mx-chain-go "$TESTNET_DIR/mx-chain-go"
   cd $TESTNET_DIR/mx-chain-go
-  git checkout 2fe51e83c455f05883947b97eff27cba93660d72
+  git checkout 7923ee22b48a0ebe851e4935aaa30fd2b58cef82
   cd ../..
 
   git clone https://github.com/multiversx/mx-chain-deploy-go "$TESTNET_DIR/mx-chain-deploy-go"

--- a/integration-tests/scripts/local-testnet.sh
+++ b/integration-tests/scripts/local-testnet.sh
@@ -19,7 +19,7 @@ cloneDependencies(){
 
   git clone https://github.com/multiversx/mx-chain-go "$TESTNET_DIR/mx-chain-go"
   cd $TESTNET_DIR/mx-chain-go
-  git checkout 7923ee22b48a0ebe851e4935aaa30fd2b58cef82
+  git checkout 32d0f017fa68add935a4f3a226c674c45d440835
   cd ../..
 
   git clone https://github.com/multiversx/mx-chain-deploy-go "$TESTNET_DIR/mx-chain-deploy-go"

--- a/integration-tests/shardChecker.go
+++ b/integration-tests/shardChecker.go
@@ -91,7 +91,7 @@ func checkShardTxs(apiTxs []gjson.Result, transactions map[string]*firehose.TxIn
 
 	protocolTx, found := transactions[txHash]
 	if !found {
-		return fmt.Errorf("checkShardTxs: could not find expected indexed tx hash: %s", apiTxs)
+		return fmt.Errorf("checkShardTxs: could not find expected indexed tx hash: %s", txHash)
 	}
 
 	txProtocolHash, err := mvxcore.CalculateHash(marshaller, hasher, protocolTx.Transaction)

--- a/integration-tests/shardChecker.go
+++ b/integration-tests/shardChecker.go
@@ -56,7 +56,13 @@ func checkShardBlock(hyperBlockNonce uint64, address string, txHash string) erro
 		return err
 	}
 
-	return checkShardAlteredAccounts(multiversxBlock.MultiversxBlock.AlteredAccounts, address)
+	err = checkShardAlteredAccounts(multiversxBlock.MultiversxBlock.AlteredAccounts, address)
+	if err != nil {
+		return err
+	}
+
+	log.Info("finished all shard checks successfully")
+	return nil
 }
 
 func checkShardBlockHeader(multiversxBlock *firehose.FirehoseBlock, shardBlocks []gjson.Result) error {

--- a/integration-tests/shardChecker.go
+++ b/integration-tests/shardChecker.go
@@ -83,12 +83,7 @@ func checkShardTxs(apiTxs []gjson.Result, transactions map[string]*firehose.TxIn
 		return fmt.Errorf("checkShardTxs: expected only one sent tx, got %d", numIndexedTxs)
 	}
 
-	txHashBytes, err := hex.DecodeString(txHash)
-	if err != nil {
-		return err
-	}
-
-	protocolTx, found := transactions[string(txHashBytes)]
+	protocolTx, found := transactions[txHash]
 	if !found {
 		return fmt.Errorf("checkShardTxs: could not find expected indexed tx hash: %s", apiTxs)
 	}

--- a/types/block.go
+++ b/types/block.go
@@ -21,7 +21,7 @@ func BlockFromProto(b *pbmultiversx.Block) (*bstream.Block, error) {
 		Number:         b.Number(),
 		PreviousId:     b.PreviousID(),
 		Timestamp:      b.Time(),
-		LibNum:         b.Number() - 1,
+		LibNum:         b.MultiversxBlock.HighestFinalBlockNonce,
 		PayloadKind:    pbbstream.Protocol_UNKNOWN,
 		PayloadVersion: 1,
 	}

--- a/types/go.mod
+++ b/types/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/protobuf v1.5.2
-	github.com/multiversx/mx-chain-core-go v1.1.31-0.20230126130945-26d928574f15
+	github.com/multiversx/mx-chain-core-go v1.1.31-0.20230130111231-561736993b1c
 	github.com/streamingfast/bstream v0.0.2-0.20220831142019-0a0b0caa04c3
 	github.com/streamingfast/pbgo v0.0.6-0.20220629184423-cfd0608e0cf4
 	google.golang.org/protobuf v1.27.1

--- a/types/go.sum
+++ b/types/go.sum
@@ -343,8 +343,8 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
 github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
 github.com/mschoch/smat v0.2.0/go.mod h1:kc9mz7DoBKqDyiRL7VZN8KvXQMWeTaVnttLRXOlotKw=
-github.com/multiversx/mx-chain-core-go v1.1.31-0.20230126130945-26d928574f15 h1:kdgVdMzFbhTqCrHfsYLautxfcSExiV0Cy6rFOAXuWM8=
-github.com/multiversx/mx-chain-core-go v1.1.31-0.20230126130945-26d928574f15/go.mod h1:8gGEQv6BWuuJwhd25qqhCOZbBSv9mk+hLeKvinSaSMk=
+github.com/multiversx/mx-chain-core-go v1.1.31-0.20230130111231-561736993b1c h1:nv1yWgwIINcGCxmZSgeAde/m7Y3ufsNjjoAX/nu24xk=
+github.com/multiversx/mx-chain-core-go v1.1.31-0.20230130111231-561736993b1c/go.mod h1:8gGEQv6BWuuJwhd25qqhCOZbBSv9mk+hLeKvinSaSMk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=


### PR DESCRIPTION
### Reasoning behind the pull request
- Tx pool contains a `map<string, tx>` fore each tx/scr/reward, etc. Each `string` **key**  in map is defined as `string([]byte(...))`, which result in non human readible strings when being indexed in firehose, such as: 

```
"Transactions": {
      "\ufffd\ufffd\u000eC\ufffd\ufffd\u001a\ufffd\ufffd\u000eZS!=\ufffd\ufffd\ufffdJ\ufffdaE\ufffd\ufffdE\\\ufffdm\ufffd\ufffd\ufffd\ufffd\ufffd": {
        "Transaction": {
          "nonce": 10,
```
  
### Proposed changes
- Refactor indexing process for each key string to be the hex encoded value of the hash. E.g.:

```
"Transactions": {
      "e8f86c78622c609913fd1a445d65a31dda2ae79ac73bc678c6069e7eacdaafc5": {
        "Transaction": {
          "nonce": 10,
```

### Additional update:
- Use `MultiversxBlock.HighestFinalBlockNonce` as `LibNum`